### PR TITLE
Remove if loops to compute two-tail p-value and introduce alternative…

### DIFF
--- a/R/statcheck.R
+++ b/R/statcheck.R
@@ -823,8 +823,8 @@ for(i in seq_len(nrow(Res))){
     upP <- 1 - 2 * abs(pt(r2t(lower[i],Res[i,]$df2),Res[i,]$df2) - .5)
     
   } else if(Res[i,]$Statistic=="Z"|Res[i,]$Statistic=="z"){
-    lowP <- 1 - 2 * abs(pnorm(lower[i],lower.tail=FALSE)) - .5)
-    upP <- 1 - 2 * abs(pnorm(lower[i],lower.tail=FALSE)) - .5)
+    lowP <- 1 - 2 * abs(pnorm(lower[i],lower.tail=FALSE) - .5)
+    upP <- 1 - 2 * abs(pnorm(lower[i],lower.tail=FALSE) - .5)
     
   } 
   

--- a/R/statcheck.R
+++ b/R/statcheck.R
@@ -811,38 +811,20 @@ for(i in seq_len(nrow(Res))){
     lowP  <- pf(upper[i],Res[i,]$df1,Res[i,]$df2,lower.tail=FALSE)
     
   } else if(Res[i,]$Statistic=="t"){
-    
-    if(lower[i]<0){
-      lowP <- pt(lower[i],Res[i,]$df2)*2
-      upP  <- pt(upper[i],Res[i,]$df2)*2
-    } else{
-      upP <- pt(-1*lower[i],Res[i,]$df2)*2
-      lowP  <- pt(-1*upper[i],Res[i,]$df2)*2
-    }
+    lowP <- 1 - 2 * abs(pt(lower[i], Res[i,]$df2, lower.tail = FALSE) - .5)
+    upP <- 1 - 2 * abs(pt(lower[i], Res[i,]$df2, lower.tail = FALSE) - .5)
     
   } else if(Res[i,]$Statistic=="Chi2"){
     upP <- pchisq(lower[i],Res[i,]$df1,lower.tail=FALSE)
     lowP  <- pchisq(upper[i],Res[i,]$df1,lower.tail=FALSE)
     
   } else if(Res[i,]$Statistic=="r"){
-    
-    if(lower[i]<0){
-      lowP <- pmin(pt(r2t(lower[i],Res[i,]$df2),Res[i,]$df2)*2,1)
-      upP  <- pmin(pt(r2t(upper[i],Res[i,]$df2),Res[i,]$df2)*2,1)
-    } else {
-      upP <- pmin(pt(-1*r2t(lower[i],Res[i,]$df2),Res[i,]$df2)*2,1)
-      lowP  <- pmin(pt(-1*r2t(upper[i],Res[i,]$df2),Res[i,]$df2)*2,1)
-    }
+    lowP <- 1 - 2 * abs(pt(r2t(lower[i],Res[i,]$df2),Res[i,]$df2) - .5)
+    upP <- 1 - 2 * abs(pt(r2t(lower[i],Res[i,]$df2),Res[i,]$df2) - .5)
     
   } else if(Res[i,]$Statistic=="Z"|Res[i,]$Statistic=="z"){
-    
-    if(lower[i]<0){
-      lowP <- pnorm(abs(lower[i]),lower.tail=FALSE)*2
-      upP  <- pnorm(abs(upper[i]),lower.tail=FALSE)*2
-    } else {
-      upP <- pnorm(lower[i],lower.tail=FALSE)*2
-      lowP  <- pnorm(upper[i],lower.tail=FALSE)*2
-    }
+    lowP <- 1 - 2 * abs(pnorm(lower[i],lower.tail=FALSE)) - .5)
+    upP <- 1 - 2 * abs(pnorm(lower[i],lower.tail=FALSE)) - .5)
     
   } 
   


### PR DESCRIPTION
Michèle, I was receiving errors because of the two-tailed p-value if loop. I changed it to remove the if loops, but it works similarly. Increases parsimony of the program and removes the need for if...else... clauses. Wanted to ensure your approval by making this pull request. Some example code showing that this gives the same two-tailed p-value below

```
> 1 - 2 * abs(pt(r2t(.4, 43), 43) - .5)
[1] 0.006479756

  Source Statistic df1 df2 Test.Comparison Value Reported.Comparison Reported.P.Value    Computed
1      1         r  NA  43               =   0.4                   =             0.43 0.006479756
                 Raw Error DecisionError OneTail OneTailedInTxt CopyPaste APAfactor
1 r(43)= .4, p = .43  TRUE          TRUE   FALSE          FALSE     FALSE         1
```