### PR TITLE
use markdown readme file

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-Readme for 'statcheck' package.
-
-This package is aimed at extracting statistical values from articles and recomputing the p values. This is useful for both meta analysis as well as checking if the p values are correct.
-
-The 'statcheck' function and related 'checkPDF' and 'checkPDFdir' functions can be used extract statistical references from articles. The original p values are reported but also recomputed. This can be useful for both meta analysis and to see if the reported p values are correct.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# statcheck
+
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/statcheck)](https://cran.r-project.org/package=statcheck)
+
+The `statcheck` package is aimed at extracting statistical values from articles
+and recomputing the _p_ values.
+
+The `statcheck()` function and related `checkPDF()` and `checkPDFdir()`
+functions can be used extract statistical references from articles. The original
+_p_ values are reported but also recomputed. This can be useful for both meta
+analysis and to see if the reported _p_ values are correct.
+
+For more information about installing and using statcheck, see [the manual on RPubs](https://rpubs.com/michelenuijten/202816).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `statcheck` package is aimed at extracting statistical values from articles
 and recomputing the _p_ values.
 
 The `statcheck()` function and related `checkPDF()` and `checkPDFdir()`
-functions can be used extract statistical references from articles. The original
+functions can be used to extract statistical references from articles. The original
 _p_ values are reported but also recomputed. This can be useful for both meta
 analysis and to see if the reported _p_ values are correct.
 

--- a/README.md
+++ b/README.md
@@ -10,4 +10,8 @@ functions can be used extract statistical references from articles. The original
 _p_ values are reported but also recomputed. This can be useful for both meta
 analysis and to see if the reported _p_ values are correct.
 
-For more information about installing and using statcheck, see [the manual on RPubs](https://rpubs.com/michelenuijten/202816).
+## Other resources
+
+For more information about installing and using statcheck, see the [manual on RPubs](https://rpubs.com/michelenuijten/202816).
+
+[statcheck.io](http://statcheck.io/) is a web-based interface for statcheck.


### PR DESCRIPTION
This is a cosmetic change to make the README file and Github page more useful.

- Added a CRAN badge that links to the CRAN page
- Added links to statcheck.io and the current manual.
- Light formatting on _p_ values and code.
- Removed repeated sentences.

CRAN converts markdown README pages to html, so these features will be preserved on CRAN.