### PR TITLE
fix bug: error in checkHTMLdir when no APA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: statcheck
 Title: Extract Statistics from Articles and Recompute P-Values
 Version: 1.4.0
-Date: 2020-04-29
+Date: 2020-04-30
 Authors@R: c(
     person("Michele B.", "Nuijten", email = "m.b.nuijten@uvt.nl", 
            role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ There have been major updates to the internal structure of statcheck. Some of th
 ## Small updates
 * Don't show a message to warn for the potential presence of one-tailed tests and other significance levels. This text was mainly distracting.
 
+## Bug fixes
+
 # statcheck 1.3.2
 <!---searched in commits on statcheck repo: `committer-date:2018-05-28..2020-03-15` --->
 

--- a/R/calc_APA_factor.R
+++ b/R/calc_APA_factor.R
@@ -3,6 +3,12 @@ calc_APA_factor <- function(pRes, Res){
   # select only the results of pRes that are from articles with at least 1 statcheck result
   pRes_selection <- pRes[pRes$Source %in% Res$Source, ]
   
+  # Source should not be a factor. This would result in a bug down the road, if
+  # one of the sources didn't have any APA results:
+  # Error in by(Res_selection, Res_selection$Source, nrow)/by(pRes_selection,  : 
+  # non-conformable arrays
+  pRes_selection$Source <- as.vector(pRes_selection$Source)
+  
   # select only the statcheck results that are from an article with at least one p value
   # this is relevant, because it sometimes happens that statcheck extracts less p values
   # p values than statcheck results. For instance in cases when a p value appears to be

--- a/tests/testthat/test-APAfactor.R
+++ b/tests/testthat/test-APAfactor.R
@@ -14,3 +14,16 @@ test_that("correct APA factor is calculated", {
   expect_equal(result12[[VAR_APAFACTOR]], c(.5, 1))
     
 })
+
+test_that("APA factor is calculated without problems if 1 source has no NHST", {
+  
+  txt1 <- "This text has 50% of its stats in APA style: t(28) = 2.20, p < .05, some other p = .035."
+  txt2 <- "This text has 0% of its stats in APA style: p < .05."
+  
+  result <- statcheck(c(txt1, txt2), messages = FALSE)
+  
+  expect_equal(result[[VAR_APAFACTOR]], .5)
+  expect_equal(nrow(result), 1)
+  
+})
+


### PR DESCRIPTION
checkHTMLdir() gave an error when the directory contained multiple files, where only some had APA results.