### PR TITLE
bug fix: ignore result when test value == NA

### DIFF
--- a/R/extract_stats.R
+++ b/R/extract_stats.R
@@ -115,6 +115,12 @@ extract_stats <- function(txt, stat){
     nhst_parsed <- nhst_parsed[!(nhst_parsed$Statistic == "r" & 
                                  nhst_parsed$Value > 1), ]
     
+    # remove rows with missing test values
+    # reason: this can happen when a test statistic has a weird minus and a 
+    # space in front of it. statcheck can't convert the weird minus in that case
+    # and would otherwise break down
+    nhst_parsed <- nhst_parsed[!is.na(nhst_parsed$Value), ]
+    
     # only return selected stats
     # to that end, rename test-types to match argument stat
     types <- as.vector(nhst_parsed$Statistic)

--- a/R/helpers-parse-stats.R
+++ b/R/helpers-parse-stats.R
@@ -169,8 +169,14 @@ extract_test_stats <- function(raw){
   test_dec <- attr(regexpr(RGX_DEC, test_value), "match.length") - 1
   test_dec[test_dec < 0] <- 0
   
+  # make test_value numeric; suppress warnings (these could arive if the test
+  # value is unusual, e.g., a weird minus followed by a space can't be made
+  # numeric)
+  # note: this needs to happen AFTER extracting the nr of decimals
+  test_value <- suppressWarnings(as.numeric(test_value))
+  
   return(data.frame(test_comp = test_comp,
-                    test_value = as.numeric(test_value),
+                    test_value = test_value,
                     test_dec = test_dec,
                     stringsAsFactors = FALSE))
   

--- a/tests/testthat/test-extract-t-tests.R
+++ b/tests/testthat/test-extract-t-tests.R
@@ -48,9 +48,9 @@ test_that("variations in the t-statistic are retrieved from text", {
   txt4 <- "t(28) > 2.20, p = .03"
   txt5 <- "t(28) = %^&2.20, p = .03" # read as -2.20
   
-  result <- statcheck(c(txt1, txt2, txt3, txt4), messages = FALSE)
+  result <- statcheck(c(txt1, txt2, txt3, txt4, txt5), messages = FALSE)
   
-  expect_equal(nrow(result), 4)
+  expect_equal(nrow(result), 5)
 })
 
 # variations p-value
@@ -106,3 +106,11 @@ test_that("t-tests with 2 dfs are not retrieved from text", {
   
   expect_output(statcheck(txt1, messages = FALSE), "did not find any results")
 })
+
+# weird encoding in minus sign followed by space
+test_that("t-values with a weird minus sign and a space do not result in errors", {
+    txt1 <- " t(553) = − 4.46, p < .0001" # this is an em dash or something
+    
+    expect_output(statcheck(txt1, messages = FALSE), "did not find any results")
+})
+


### PR DESCRIPTION
this happened for instance when a minus sign was weirdly encoded AND followed by a space