### PR TITLE
bug fix: also ignore capital Z with df

### DIFF
--- a/R/regex.R
+++ b/R/regex.R
@@ -6,7 +6,7 @@ RGX_T <- "t"
 RGX_R <- "r"
 RGX_Q <- "Q\\s?-?\\s?(w|W|(w|W)ithin|b|B|(b|B)etween)?"
 RGX_F <- "F"
-RGX_CHI2 <- "((\\[CHI\\]|\\[DELTA\\]G)\\s?|(\\s[^trFzQWnD ]\\s?)|([^trFzQWnD ]2\\s?))2?"
+RGX_CHI2 <- "((\\[CHI\\]|\\[DELTA\\]G)\\s?|(\\s[^trFzZQWnD ]\\s?)|([^trFzZQWnD ]2\\s?))2?"
 RGX_Z <- "([^a-z](z|Z))"
 
 # degrees of freedom

--- a/tests/testthat/test-extract-z-tests.R
+++ b/tests/testthat/test-extract-z-tests.R
@@ -53,8 +53,9 @@ test_that("upper case z-tests are retrieved from text", {
 
 # z test cannot have df
 test_that("a z followed by degrees of freedom is not matched", {
-  txt <- " z(28) = 2.20, p = .03"
+  txt1 <- " z(28) = 2.20, p = .03"
+  txt2 <- " Z(28) = 2.20, p = .03"
   
-  expect_output(statcheck(txt, messages = FALSE), "did not find any results")
+  expect_output(statcheck(c(txt1, txt2), messages = FALSE), "did not find any results")
   
 })


### PR DESCRIPTION
otherwise cases like this: " Z(28) = 2.20, p = .0" will result in an error