### PR TITLE
bug fix: don't extract multiple comparisons

### DIFF
--- a/R/extract_stats.R
+++ b/R/extract_stats.R
@@ -76,13 +76,28 @@ extract_stats <- function(txt, stat){
     
     test <- extract_test_stats(raw = nhst_raw[i])
     
-    test_stats <- rbind(test_stats, test)
+    # ignore any cases with more than 1 test comparison (e.g., z >= 2)
+    if(nrow(test) > 1){
+      test <- data.frame(test_comp = NA,
+                         test_value = NA,
+                         test_dec = NA)
+    } 
+    
+    test_stats <- rbind(test_stats, test)  
     
     # extract p-comparison and p-value
     
     p <- extract_p_value(raw = nhst_raw[i])
     
+    # ignore any cases with more than 1 test comparison (e.g., p >= .01)
+    if(nrow(p) > 1){
+      p <- data.frame(p_comp = NA,
+                      p_value = NA,
+                      p_dec = NA)
+    }
+    
     pvals <- rbind(pvals, p)
+    
     
   }
   
@@ -121,6 +136,12 @@ extract_stats <- function(txt, stat){
     # space in front of it. statcheck can't convert the weird minus in that case
     # and would otherwise break down
     nhst_parsed <- nhst_parsed[!is.na(nhst_parsed$Value), ]
+    
+    # remove missing test comparisons or p comparisons 
+    # reason: these are marked as NA in cases where multiple comparisons were
+    # reported. E.g., t(23) >= ..., p >= ...
+    nhst_parsed <- nhst_parsed[!is.na(nhst_parsed$Test.Comparison) &
+                                 !is.na(nhst_parsed$Reported.Comparison), ]
     
     # only return selected stats
     # to that end, rename test-types to match argument stat

--- a/tests/testthat/test-extract-t-tests.R
+++ b/tests/testthat/test-extract-t-tests.R
@@ -114,3 +114,10 @@ test_that("t-values with a weird minus sign and a space do not result in errors"
     expect_output(statcheck(txt1, messages = FALSE), "did not find any results")
 })
 
+# multiple comparison signs 
+test_that("t-values with multiple comparison signs are not retrieved", {
+  txt1 <- "t(38) >= 2.25, p = .03"
+  txt2 <- "t(38) = 2.25, p >= .03"
+  
+  expect_output(statcheck(c(txt1, txt2), messages = FALSE), "did not find any results")
+})


### PR DESCRIPTION
e.g. z >= ..., or p <= ... should be ignored