### PR TITLE
Add the option to ignore case

### DIFF
--- a/R/extract_stats.R
+++ b/R/extract_stats.R
@@ -1,4 +1,4 @@
-extract_stats <- function(txt, stat){
+extract_stats <- function(txt, stat, ignore_case = FALSE){
   
   # step 1: extract all NHST results from text -----------------------------------
   
@@ -8,9 +8,8 @@ extract_stats <- function(txt, stat){
                               # nhst is the regex for nhst results
                               # it came from the regex.R script within the package
                               pattern = RGX_NHST,
-                              # don't ignore case here: we only want to extract
-                              # stats reported in a specific way (e.g., t, not T)
-                              ignore.case = FALSE) 
+                              # option to only extract stats reported in a specific way (e.g., t, not T)
+                              ignore.case = ignore_case) 
   
   # if there are no nhst results in the text, return an empty data frame
   if(is.null(nhst_raw)){
@@ -33,7 +32,8 @@ extract_stats <- function(txt, stat){
     
     # extract the test types from the nhst results 
     test_raw <- extract_pattern(txt = nhst_raw[i],
-                                pattern = RGX_TEST_TYPE)
+                                pattern = RGX_TEST_TYPE,
+                                ignore.case = ignore_case)
     
     # classify the test types in standard classifications
     
@@ -43,25 +43,25 @@ extract_stats <- function(txt, stat){
     # otherwise the regex for t will also match Qwithin and Qbetween, because
     # both have a t in them. Similarly: first check for Qb, because Qbetween
     # also has a w in it
-    if (grepl(pattern = RGX_Q, x = test_raw)){
+    if (grepl(pattern = RGX_Q, x = test_raw, ignore.case = ignore_case)){
       
       # distinguish between Q, Qw, and Qb
-      if(grepl(pattern = RGX_QB, x = test_raw)){
+      if(grepl(pattern = RGX_QB, x = test_raw, ignore.case = ignore_case)){
         test_type[i] <- "Qb"
-      } else if (grepl(pattern = RGX_QW, x = test_raw)){
+      } else if (grepl(pattern = RGX_QW, x = test_raw, ignore.case = ignore_case)){
         test_type[i] <- "Qw"
       } else {
         test_type[i] <- "Q"
       }
-    } else if(grepl(pattern = RGX_T, x = test_raw)){
+    } else if(grepl(pattern = RGX_T, x = test_raw, ignore.case = ignore_case)){
       test_type[i] <- "t"
-    } else if (grepl(pattern = RGX_F, x = test_raw)){
+    } else if (grepl(pattern = RGX_F, x = test_raw, ignore.case = ignore_case)){
       test_type[i] <- "F"
-    } else if (grepl(pattern = RGX_R, x = test_raw)){
+    } else if (grepl(pattern = RGX_R, x = test_raw, ignore.case = ignore_case)){
       test_type[i] <- "r"
-    } else if (grepl(pattern = RGX_Z, x = test_raw)){
+    } else if (grepl(pattern = RGX_Z, x = test_raw, ignore.case = ignore_case)){
       test_type[i] <- "Z"
-    } else if (grepl(pattern = RGX_CHI2, x = test_raw)){
+    } else if (grepl(pattern = RGX_CHI2, x = test_raw, ignore.case = ignore_case)){
       test_type[i] <- "Chi2"
     }
     

--- a/R/statcheck.R
+++ b/R/statcheck.R
@@ -121,7 +121,8 @@ statcheck <- function(texts,
                       pZeroError = TRUE,
                       OneTailedTxt = FALSE,
                       AllPValues = FALSE,
-                      messages = TRUE){
+                      messages = TRUE,
+                      ignore_case = TRUE){
   
   # We need empty data frames to store extracted statistics in
   # One for NHST results (Res) and one for p-values (pRes)
@@ -180,7 +181,8 @@ statcheck <- function(texts,
     # reported NHST results and parses it so that the separate elements are
     # returned in one large dataframe
     nhst <- extract_stats(txt = txt,
-                          stat = stat)
+                          stat = stat,
+                          ignore_case = ignore_case)
     
     # append and close: same logic as for the pvalues dataframe above
     if(nrow(nhst) > 0){

--- a/R/statcheck.R
+++ b/R/statcheck.R
@@ -80,6 +80,8 @@
 #' results in APA format.
 #' @param messages Logical. If TRUE, statcheck will print a progress bar while 
 #' it's extracting statistics from text.
+#' @param ignore_case Logical. If TRUE, statcheck will ignore the difference
+#' between upper and lower case letters, treating f and F the same.
 #' 
 #' @return A data frame containing for each extracted statistic:
 #' \describe{

--- a/man/statcheck.Rd
+++ b/man/statcheck.Rd
@@ -13,7 +13,8 @@ statcheck(
   pZeroError = TRUE,
   OneTailedTxt = FALSE,
   AllPValues = FALSE,
-  messages = TRUE
+  messages = TRUE,
+  ignore_case = TRUE
 )
 }
 \arguments{
@@ -50,6 +51,9 @@ results in APA format.}
 
 \item{messages}{Logical. If TRUE, statcheck will print a progress bar while 
 it's extracting statistics from text.}
+
+\item{ignore_case}{Logical. If TRUE, statcheck will ignore the difference
+between upper and lower case letters, treating f and F the same.}
 }
 \value{
 A data frame containing for each extracted statistic:

--- a/tests/testthat/test-extract-t-tests.R
+++ b/tests/testthat/test-extract-t-tests.R
@@ -92,10 +92,16 @@ test_that("incorrect punctuation in t-tests are not retrieved from text", {
   expect_output(statcheck(c(txt1, txt2), messages = FALSE), "did not find any results")
 })
 
-test_that("capital t's are not retrieved from text", {
+# case sensitivity
+test_that("case sensitivity is optional", {
   txt1 <- "T(28) = 2.20, p = .03"
+  txt2 <- "t(28) = 2.20, p = .03"
   
-  expect_output(statcheck(txt1, messages = FALSE), "did not find any results")
+  expect_output(statcheck(txt1, messages = FALSE, ignore_case = FALSE), "did not find any results")
+  expect_equal(
+    tolower(statcheck(txt1, messages = FALSE, ignore_case = TRUE)$raw),
+    tolower(statcheck(txt2, messages = FALSE, ignore_case = TRUE)$raw)
+  )
 })
 
 # not a p-value


### PR DESCRIPTION
Statcheck ignores statistical tests if the letter case is wrong such as the incorrect "f(12,34) = 0.56, P = 0.048" instead of correct "F(12,34) = 0.56, p = 0.048". 

While I understand the value in checking for proper APA formatting, confusing upper and lower case usage is reasonably common, especially for F-tests. I suspect that the more common goal of a StatCheck user is to find and check as many reported statistics as possible, rather than only those the perfectly comply with APA formatting. So I suggest optimizing for that use case by defaulting to ignoring case and giving users the option to more strictly follow APA formatting.

Questions: 
* For the parameter `ignore_case`, would you prefer snake_case or camelCase?
* Are there any examples where the case DOES matter? If so, it can be selectively turned on/off per regex pattern.