### PR TITLE
tweak chi-squared

### DIFF
--- a/R/regex.R
+++ b/R/regex.R
@@ -9,7 +9,7 @@ RGX_F <- "F"
 RGX_Z <- "([^a-z](z|Z))"
 # for chi2: effectively extract everything that is NOT a t, r, F, z, Q, W, n, or
 # D, followed by *maybe* a 2 (and later followed by a result in a chi2 layout)
-RGX_CHI2 <- "((\\s[^trFzZQWnD ]\\s?)|([^trFzZQWnD ](2|\u00B2)\\s?))"
+RGX_CHI2 <- "((\\s[^trFzZQWnD ](2|\u00B2)?\\s?)|([^trFzZQWnD ](2|\u00B2)\\s?))"
 
 # degrees of freedom
 # the way dfs are reported differs per test type, except for t, r, and Q, where

--- a/R/regex.R
+++ b/R/regex.R
@@ -9,7 +9,7 @@ RGX_F <- "F"
 RGX_Z <- "([^a-z](z|Z))"
 # for chi2: effectively extract everything that is NOT a t, r, F, z, Q, W, n, or
 # D, followed by *maybe* a 2 (and later followed by a result in a chi2 layout)
-RGX_CHI2 <- "((\\s[^trFzZQWnD ](2|\u00B2)?\\s?)|([^trFzZQWnD ](2|\u00B2)\\s?))"
+RGX_CHI2 <- "((\\s[^trFzZQWnD ](\\^2|\u00B2)?\\s?)|([^trFzZQWnD ](\\^2|2|\u00B2)\\s?))"
 
 # degrees of freedom
 # the way dfs are reported differs per test type, except for t, r, and Q, where

--- a/R/regex.R
+++ b/R/regex.R
@@ -7,9 +7,9 @@ RGX_R <- "r"
 RGX_Q <- "Q\\s?-?\\s?(w|W|(w|W)ithin|b|B|(b|B)etween)?"
 RGX_F <- "F"
 RGX_Z <- "([^a-z](z|Z))"
-# for chi2: effectively extract everything that is NOT a t, r, F, z, Q, W, n, or 
+# for chi2: effectively extract everything that is NOT a t, r, F, z, Q, W, n, or
 # D, followed by *maybe* a 2 (and later followed by a result in a chi2 layout)
-RGX_CHI2 <- "((\\s[^trFzZQWnD ]\\s?)|([^trFzZQWnD ]2\\s?))2?"
+RGX_CHI2 <- "((\\s[^trFzZQWnD ]\\s?)|([^trFzZQWnD ](2|\u00B2)\\s?))"
 
 # degrees of freedom
 # the way dfs are reported differs per test type, except for t, r, and Q, where
@@ -28,12 +28,12 @@ RGX_Q_DF <- paste0("(", RGX_Q, "\\s?", RGX_DF_T_R_Q, ")")
 RGX_F_DF <- paste0("(", RGX_F, "\\s?", RGX_DF_F, ")")
 RGX_CHI2_DF <- paste0("(", RGX_CHI2, "\\s?", RGX_DF_CHI2, ")")
 
-RGX_TEST_DF <- paste0("(", RGX_T_DF, "|", RGX_R_DF, "|", RGX_Q_DF, "|", RGX_F_DF, 
+RGX_TEST_DF <- paste0("(", RGX_T_DF, "|", RGX_R_DF, "|", RGX_Q_DF, "|", RGX_F_DF,
                       "|", RGX_CHI2_DF, "|", RGX_Z, ")")
 
 # test value
 # this is the same for every type of test
-# the part "[^a-zA-Z\\d\\.]{0,3}" is to extract punctuation marks that could 
+# the part "[^a-zA-Z\\d\\.]{0,3}" is to extract punctuation marks that could
 # signal a weirdly encoded minus sign
 # note that impossible values such as r > 1 are excluded at a later stage
 RGX_TEST_VALUE <- "[<>=]\\s?[^a-zA-Z\\d\\.]{0,3}\\s?\\d*,?\\d*\\.?\\d+\\s?,"
@@ -53,7 +53,7 @@ RGX_NHST <- paste(RGX_TEST_DF, RGX_TEST_VALUE, RGX_P_NS, sep = "\\s?")
 
 # match everything up until the first occurence of a "(" with a positive look
 # ahead. A "(" signals the start of the degrees of freedom, so everything before
-# that should be the test statistic. Also match the regex for a z-test 
+# that should be the test statistic. Also match the regex for a z-test
 # (because a z-test has no df)
 
 RGX_OPEN_BRACKET <- "(.+?(?=\\())"
@@ -70,7 +70,7 @@ RGX_QB <- "b"
 # regex for degrees of freedom
 
 # combine the separate regexes for the different types of dfs
-# in one all-encompassing regex. Group the df-types with parentheses and 
+# in one all-encompassing regex. Group the df-types with parentheses and
 # separate with an OR sign
 RGX_DF <- paste0("(", RGX_DF_T_R_Q, ")|(", RGX_DF_F, ")|(", RGX_DF_CHI2, ")")
 
@@ -86,14 +86,14 @@ RGX_1000_SEP <- "(?<=\\d),(?=\\d+)"
 RGX_DEC <- "\\.\\d+"
 
 # regex for weird symbols that should be a minus sign
-# match potentially a space, followed by one or more characters that are not a 
-# digit, period, or space, followed by a digit or period (using a positive 
+# match potentially a space, followed by one or more characters that are not a
+# digit, period, or space, followed by a digit or period (using a positive
 # lookahead)
 RGX_WEIRD_MINUS <- "\\s?[^\\d\\.\\s]+(?=\\d|\\.)"
 
 # regex for weird df1 in F-tests
-# for some reason, typesetting in articles sometimes goes wrong with 
-# F-tests and when df1 == 1, it gets typeset as the letter l or I 
+# for some reason, typesetting in articles sometimes goes wrong with
+# F-tests and when df1 == 1, it gets typeset as the letter l or I
 RGX_DF1_I_L <- "I|l"
 
 ################################################################################

--- a/tests/testthat/test-extract-chi2-tests.R
+++ b/tests/testthat/test-extract-chi2-tests.R
@@ -5,9 +5,9 @@ context("Extract chi2-tests from string")
 # standard chi2-test
 test_that("chi2-tests are correctly parsed", {
   txt1 <- "chi2(28) = 2.20, p = .03"
-  
+
   result <- statcheck(txt1, messages = FALSE)
-  
+
   expect_equal(nrow(result), 1)
   expect_equal(as.character(result[[VAR_TYPE]]), "Chi2")
   expect_equal(result[[VAR_DF1]], 28)
@@ -23,9 +23,9 @@ test_that("chi2-tests are correctly parsed", {
 test_that("chi2-tests are retrieved from sentences", {
   txt1 <- "The effect was very significant, chi2(28) = 2.20, p = .03."
   txt2 <- "Both effects were very significant, chi2(28) = 2.20, p = .03, chi2(28) = 1.23, p = .04."
-  
+
   result <- statcheck(c(txt1, txt2), messages = FALSE)
-  
+
   expect_equal(nrow(result), 3)
   expect_equal(as.character(result[[VAR_SOURCE]]), c("1", "2", "2"))
 })
@@ -35,10 +35,13 @@ test_that("variations in spelling the Greek letter chi are picked up", {
   txt1 <- "X2(28) = 2.20, p = .03"
   txt2 <- "x2(28) = 2.20, p = .03"
   txt3 <- "chi_2(28) = 2.20, p = .03"
-  
-  result <- statcheck(c(txt1, txt2, txt3), messages = FALSE)
-  
-  expect_equal(nrow(result), 3)
+  # lowercase chi
+  txt4 <- "\u03C72(28) = 2.20, p = .03"
+  # superscript 2
+  txt5 <- "chi\u00B2(28) = 2.20, p = .03"
+  result <- statcheck(c(txt1, txt2, txt3, txt4, txt5), messages = FALSE)
+
+  expect_equal(nrow(result), 5)
 })
 
 # variation in degrees of freedom
@@ -46,20 +49,20 @@ test_that("different variations in df of chi2 are parsed correctly", {
   txt1 <- "chi2(28, N = 129) = 2.2, p = .03"
   txt2 <- "chi2(1, N = 11,455) = 16.78, p <.001"
   txt3 <- "chi2(1, n = 81) = 3.25, p = 0.07" # also extract lowercase n
-  
+
   result <- statcheck(c(txt1, txt2, txt3), messages = FALSE)
-  
+
   expect_equal(nrow(result), 3)
-  
+
 })
 
 # variation in spacing
 test_that("chi2-tests with different spacing are retrieved from text", {
   txt1 <- " chi2 ( 28 ) = 2.20 , p = .03"
   txt2 <- "chi2(28)=2.20,p=.03"
-  
+
   result <- statcheck(c(txt1, txt2), messages = FALSE)
-  
+
   expect_equal(nrow(result), 2)
 })
 

--- a/tests/testthat/test-extract-chi2-tests.R
+++ b/tests/testthat/test-extract-chi2-tests.R
@@ -37,11 +37,22 @@ test_that("variations in spelling the Greek letter chi are picked up", {
   txt3 <- "chi_2(28) = 2.20, p = .03"
   # lowercase chi
   txt4 <- "\u03C72(28) = 2.20, p = .03"
-  # superscript 2
-  txt5 <- "chi\u00B2(28) = 2.20, p = .03"
-  result <- statcheck(c(txt1, txt2, txt3, txt4, txt5), messages = FALSE)
+  set <- c(txt1, txt2, txt3, txt4)
+  result <- statcheck(set, messages = FALSE)
 
-  expect_equal(nrow(result), 5)
+  expect_equal(nrow(result), length(set))
+})
+
+# variations in extracted 2
+test_that("variations in spelling the chi-squared 2 are picked up", {
+  txt1 <- "X2(28) = 2.20, p = .03"
+  txt2 <- "x^2(28) = 2.20, p = .03"
+  # superscript 2
+  txt3 <- "chi\u00B2(28) = 2.20, p = .03"
+  set <- c(txt1, txt2, txt3)
+  result <- statcheck(set, messages = FALSE)
+
+  expect_equal(nrow(result), length(set))
 })
 
 # variation in degrees of freedom


### PR DESCRIPTION
Make regex more closely match description in comment. Regex used to match

- space + character + optional 2
- character + 2 + optional 2

Now matches

- space + character + optional 2
- character + 2
- character + ^2

Allow chi-squared to work with superscript 2 and test against `χ` and `²` in the unit tests. 

Use of `\uDDDD` escape codes allows R to handle special characters in a CRAN-safe way. 