### PR TITLE
Bug minus as dash

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: statcheck
 Title: Extract Statistics from Articles and Recompute P-Values
-Version: 1.6.1
-Date: 2025-06-20
+Version: 1.6.1.9000
+Date: 2026-01-26
 Authors@R: c(
     person("Michele B.", "Nuijten", , "m.b.nuijten@uvt.nl", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-1468-8585")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# statcheck 1.6.1
+# statcheck 1.6.1.9000
 
 ## Major changes
 
@@ -6,7 +6,7 @@
 * Finetuned html and pdf conversion to better read chi-square tests.
 
 ## Bug fixes
-
+* No longer give a warning when there is a minus sign used as a dash right after a statistical test (e.g., "p = .09-we are very sad"). HT Lisa DeBruine!
 
 # statcheck 1.6.0
 

--- a/R/regex.R
+++ b/R/regex.R
@@ -41,7 +41,7 @@ RGX_TEST_VALUE <- "[<>=]\\s?[^a-zA-Z\\d\\.]{0,3}\\s?\\d*,?\\d*\\.?\\d+\\s?,"
 # p-values
 # this is the same for every type of test
 RGX_NS <- "([^a-z]n\\.?s\\.?)"
-RGX_P <- "(p\\s?[<>=]\\s?\\d?\\.\\d+e?-?\\d*)"
+RGX_P <- "(p\\s?[<>=]\\s?\\d?\\.\\d+(?:[eE]-?\\d+)?)"
 RGX_P_NS <- paste0("(", RGX_NS, "|", RGX_P, ")")
 
 # full result

--- a/tests/testthat/test-extract-pvalues.R
+++ b/tests/testthat/test-extract-pvalues.R
@@ -28,6 +28,16 @@ test_that("results reported as ns are correctly parsed", {
   expect_true(is.na(result[[VAR_REPORTED_P]]))
 })
 
+
+# minus sign as a dash, following a p-value
+test_that("minus signs used as a dash are correctly parsed", {
+  txt <- "p = .09-and we are sad"
+  
+  expect_no_warning(statcheck(txt, messages = FALSE,
+                   AllPValues = TRUE))
+  
+})
+
 # test if the following non p-values are not retrieved ------------------
 
 # page number


### PR DESCRIPTION
minor bug fix: No longer give a warning when there is a minus sign used as a dash right after a statistical test (e.g., "p = .09-we are very sad"). HT Lisa DeBruine!